### PR TITLE
Add type to libwrapper dependency so that it is recognized by Foundry

### DIFF
--- a/module.json
+++ b/module.json
@@ -15,7 +15,8 @@
   "dependencies": [
 	  {
 		  "name":"lib-wrapper",
-		  "manifest":"https://github.com/ruipin/fvtt-lib-wrapper/releases/latest/download/module.json"
+		  "manifest":"https://github.com/ruipin/fvtt-lib-wrapper/releases/latest/download/module.json",
+		  "type": "module"
 	  }
   ],
   "url": "https://github.com/ofdiceandmagic/FVTT-collapsible-journal-sections",


### PR DESCRIPTION
Currently I am not prompted to enable libwrapper when enabling the module